### PR TITLE
Use Serve Deployment to run and health check the Agent

### DIFF
--- a/start_anyscale_service.py
+++ b/start_anyscale_service.py
@@ -1,9 +1,11 @@
 import argparse
 import logging
 import os
-import ray
 import shutil
 import subprocess
+
+import ray
+from ray import serve
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--queue", type=str)
@@ -11,15 +13,21 @@ args = parser.parse_args()
 
 ray.init()
 
-ANYSCALE_PREFECT_DIR = os.path.dirname(os.path.realpath(__file__))
+serve.start(detached=True)
 
-shutil.copy(os.path.join(ANYSCALE_PREFECT_DIR, "anyscale_prefect_agent.py"), "/home/ray/")
+@serve.deployment
+class PrefectAgentDeployment:
+    def __init__(self):
+        anyscale_prefect_dir = os.path.dirname(os.path.realpath(__file__))
+        shutil.copy(os.path.join(anyscale_prefect_dir, "anyscale_prefect_agent.py"), "/home/ray/")
 
-# The prefect agent is timing out on the connection to the prefect control
-# plane after about 24h of inactivity. If this happens, restart it.
-while True:
-    logging.info(f"Starting prefect agent for queue {args.queue}")
-    try:
-        subprocess.check_call(["prefect", "agent", "start", "-q", args.queue])
-    except Exception:
-        logging.exception("Restarting prefect agent due to exception")
+        # The prefect agent is timing out on the connection to the prefect control
+        # plane after about 24h of inactivity. If this happens, restart it.
+        while True:
+            logging.info(f"Starting prefect agent for queue {args.queue}")
+            try:
+                subprocess.check_call(["prefect", "agent", "start", "-q", args.queue])
+            except Exception:
+                logging.exception("Restarting prefect agent due to exception")
+
+serve.run(PrefectAgentDeployment.bind())

--- a/start_anyscale_service.py
+++ b/start_anyscale_service.py
@@ -16,7 +16,7 @@ serve.start(detached=True)
 
 app = FastAPI()
 
-@serve.deployment(route_prefix="/")
+@serve.deployment(route_prefix="/", num_replicas=1)
 @serve.ingress(app)
 class PrefectAgentDeployment:
     def __init__(self):

--- a/start_anyscale_service.py
+++ b/start_anyscale_service.py
@@ -4,6 +4,7 @@ import os
 import shutil
 import subprocess
 
+from fastapi import FastAPI
 import ray
 from ray import serve
 
@@ -11,16 +12,25 @@ parser = argparse.ArgumentParser()
 parser.add_argument("--queue", type=str)
 args = parser.parse_args()
 
-ray.init()
-
 serve.start(detached=True)
 
-@serve.deployment
+app = FastAPI()
+
+@serve.deployment(route_prefix="/")
+@serve.ingress(app)
 class PrefectAgentDeployment:
     def __init__(self):
         anyscale_prefect_dir = os.path.dirname(os.path.realpath(__file__))
         shutil.copy(os.path.join(anyscale_prefect_dir, "anyscale_prefect_agent.py"), "/home/ray/")
 
         self.agent = subprocess.Popen(["prefect", "agent", "start", "-q", args.queue])
+
+    @app.get("/healthcheck")
+    def healthcheck(self):
+        poll = self.agent.poll()
+        if poll is None:
+            return
+        else:
+            raise RuntimeError("Prefect agent died")
 
 serve.run(PrefectAgentDeployment.bind())

--- a/start_anyscale_service.py
+++ b/start_anyscale_service.py
@@ -21,6 +21,6 @@ class PrefectAgentDeployment:
         anyscale_prefect_dir = os.path.dirname(os.path.realpath(__file__))
         shutil.copy(os.path.join(anyscale_prefect_dir, "anyscale_prefect_agent.py"), "/home/ray/")
 
-        self.agent = subprocess.Popen((["prefect", "agent", "start", "-q", args.queue])
+        self.agent = subprocess.Popen(["prefect", "agent", "start", "-q", args.queue])
 
 serve.run(PrefectAgentDeployment.bind())

--- a/start_anyscale_service.py
+++ b/start_anyscale_service.py
@@ -21,13 +21,6 @@ class PrefectAgentDeployment:
         anyscale_prefect_dir = os.path.dirname(os.path.realpath(__file__))
         shutil.copy(os.path.join(anyscale_prefect_dir, "anyscale_prefect_agent.py"), "/home/ray/")
 
-        # The prefect agent is timing out on the connection to the prefect control
-        # plane after about 24h of inactivity. If this happens, restart it.
-        while True:
-            logging.info(f"Starting prefect agent for queue {args.queue}")
-            try:
-                subprocess.check_call(["prefect", "agent", "start", "-q", args.queue])
-            except Exception:
-                logging.exception("Restarting prefect agent due to exception")
+        self.agent = subprocess.Popen((["prefect", "agent", "start", "-q", args.queue])
 
 serve.run(PrefectAgentDeployment.bind())


### PR DESCRIPTION
This puts the Prefect agent into a Serve Deployment to avoid the application staying in the "Updating" stage while it is running.

It also does proper health checking of the agent and will restart the deployment if the agent fails.