### PR TITLE
Log to the service instead of a separate file

### DIFF
--- a/prefect-agent-service.yaml
+++ b/prefect-agent-service.yaml
@@ -1,4 +1,4 @@
-name: prefect-agent-6
+name: prefect-agent-10
 entrypoint: pip install prefect && PREFECT_API_URL=$PREFECT_API_URL PREFECT_API_KEY=$PREFECT_API_KEY python start_anyscale_service.py --queue test
 runtime_env:
   working_dir: https://github.com/anyscale/prefect-anyscale/archive/refs/tags/v0.0.6.zip

--- a/start_anyscale_service.py
+++ b/start_anyscale_service.py
@@ -24,14 +24,9 @@ class PrefectAgentDeployment:
         anyscale_prefect_dir = os.path.dirname(os.path.realpath(__file__))
         shutil.copy(os.path.join(anyscale_prefect_dir, "anyscale_prefect_agent.py"), "/home/ray/")
 
-        # Logfiles will be closed when the process exits
-        prefect_agent_id = uuid.uuid4()
-        self.logfile_out = open(f"/tmp/prefect-agent-{prefect_agent_id}.out", "w")
-        self.logfile_err = open(f"/tmp/prefect-agent-{prefect_agent_id}.err", "w")
         self.agent = subprocess.Popen(
             ["prefect", "agent", "start", "-q", args.queue],
             env=dict(os.environ, **prefect_env),
-            stdout=self.logfile_out, stderr=self.logfile_err,
         )
 
     @app.get("/healthcheck")


### PR DESCRIPTION
This makes it so we can use the Ray Dashboard to see the log files instead of having to keep track of a separate file.