### PR TITLE
Document infra override and fix compute config

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,3 +122,25 @@ You can now schedule new runs with this deployment from the Prefect UI
 ![submit prefect run](./doc/prefect_submit_run.png)
 
 and it will be executed as an Anyscale Job on an autoscaling Ray Cluster which has the same setup as the development setup described above.
+
+#### Overriding properties of the infra block
+
+You can override properties of the Anyscale infra block at runtime like this:
+
+```python
+import prefect
+from prefect.filesystems import S3
+from prefect_anyscale import AnyscaleJob
+
+from prefect_test import count_to
+
+deployment = prefect.deployments.Deployment.build_from_flow(
+    flow=count_to,
+    name="prefect_test_custom",
+    work_queue_name="test",
+    storage=S3.load("test-storage"),
+    infrastructure=AnyscaleJob.load("test-infra"),
+    infra_overrides={"compute_config": "test-compute-config"}
+)
+deployment.apply()
+```

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ and it will be executed as an Anyscale Job on an autoscaling Ray Cluster which h
 
 #### Overriding properties of the infra block
 
-You can override properties of the Anyscale infra block at runtime like this:
+You can override properties of the Anyscale infra block in a deployment like this
 
 ```python
 import prefect

--- a/ci/prefect-agent-service-ci.yaml
+++ b/ci/prefect-agent-service-ci.yaml
@@ -1,4 +1,4 @@
-name: prefect-agent-25
+name: prefect-agent-26
 cloud: "anyscale_v2_default_cloud"
 ray_serve_config:
   import_path: start_anyscale_service:entrypoint
@@ -7,6 +7,6 @@ ray_serve_config:
       PREFECT_API_URL: $PREFECT_API_URL
       PREFECT_API_KEY: $PREFECT_API_KEY
       ANYSCALE_PREFECT_QUEUE: test
-      ANYSCALE_PREFECT_DEVELOPMENT: 1
+      ANYSCALE_PREFECT_DEVELOPMENT: "1"
     working_dir: .
     upload_path: "s3://anyscale-prefect-integration-test/github-working-dir/"

--- a/ci/prefect-agent-service-ci.yaml
+++ b/ci/prefect-agent-service-ci.yaml
@@ -1,5 +1,5 @@
-name: prefect-agent-24
-cloud: "anyscale_v2_default_cloud_vpn"
+name: prefect-agent-25
+cloud: "anyscale_v2_default_cloud"
 ray_serve_config:
   import_path: start_anyscale_service:entrypoint
   runtime_env:
@@ -7,6 +7,6 @@ ray_serve_config:
       PREFECT_API_URL: $PREFECT_API_URL
       PREFECT_API_KEY: $PREFECT_API_KEY
       ANYSCALE_PREFECT_QUEUE: test
-    pip: ["prefect-anyscale"]
+      ANYSCALE_PREFECT_DEVELOPMENT: 1
     working_dir: .
     upload_path: "s3://anyscale-prefect-integration-test/github-working-dir/"

--- a/ci/submit_prefect_run_and_check.py
+++ b/ci/submit_prefect_run_and_check.py
@@ -13,7 +13,8 @@ deployment = prefect.deployments.Deployment.build_from_flow(
     name="prefect_test",
     work_queue_name="test",
     storage=S3.load("test-storage-github"),
-    infrastructure=AnyscaleJob.load("anyscale-job-infra")
+    infrastructure=AnyscaleJob.load("anyscale-job-infra"),
+    infra_overrides={"compute_config": "test-compute-config"},
 )
 deployment.apply()
 

--- a/prefect_anyscale/infrastructure.py
+++ b/prefect_anyscale/infrastructure.py
@@ -58,9 +58,9 @@ class AnyscaleJob(Infrastructure):
         job_name = "prefect-job-" + flow_run_id
 
         content = """
-        name: "{}"
-        entrypoint: "{}"
-        """.format(job_name, cmd)
+name: "{}"
+entrypoint: "{}"
+""".format(job_name, cmd)
 
         if self.compute_config:
             content += 'compute_config: "{}"\n'.format(self.compute_config)

--- a/start_anyscale_service.py
+++ b/start_anyscale_service.py
@@ -25,6 +25,8 @@ class PrefectAgentDeployment:
         else:
             raise RuntimeError("Prefect agent died")
 
+if os.environ.get("ANYSCALE_PREFECT_DEVELOPMENT", "0") == "1":
+    subprocess.check_call(["pip", "install", "-e", "."])
 
 entrypoint = PrefectAgentDeployment.bind({
     "PREFECT_API_URL": os.environ["PREFECT_API_URL"],


### PR DESCRIPTION
This documents how to use the infra override in a prefect deployment to set the compute config and fixes the compute config and cluster environment pass through, as well as adding a regression test.